### PR TITLE
Add needs as dependency

### DIFF
--- a/.github/workflows/kuksa_databroker-perf_build.yml
+++ b/.github/workflows/kuksa_databroker-perf_build.yml
@@ -124,7 +124,7 @@ jobs:
     name: Create multiarch container
     runs-on: ubuntu-latest
 
-    needs: [build]
+    needs: [build, check_ghcr_push]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Needs are likely needed for correct evaluation. so that we push a docker container when merging