### PR TITLE
Shutdown provider before subscriber

### DIFF
--- a/src/subscribers/subscriber_trait.rs
+++ b/src/subscribers/subscriber_trait.rs
@@ -31,9 +31,6 @@ pub enum Error {
 
     #[error("signal '{0}' not found")]
     SignalNotFound(String),
-
-    #[error("Received shutdown signal")]
-    Shutdown,
 }
 
 #[async_trait]


### PR DESCRIPTION
Now, the number of datapoints sent are exactly the same as received