### PR TITLE
Do not count iterations aborted during shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "databroker-perf"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "databroker-perf"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -500,7 +500,9 @@ async fn measurement_loop(ctx: &mut MeasurementContext) -> Result<(u64, u64)> {
             }
         }
 
-        iterations += 1;
+        if ctx.shutdown_handler.state.running.load(Ordering::SeqCst) {
+            iterations += 1;
+        }
     }
     Ok((iterations, skipped))
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -22,6 +22,7 @@ use tokio::{
     sync::broadcast::{self, Sender},
 };
 
+#[derive(Clone)]
 pub struct ShutdownHandler {
     pub trigger: Sender<()>,
     pub state: Arc<State>,


### PR DESCRIPTION
Without this the displayed number of published updates will not match the number of received updates when aborting a run.

Also remove a superfluous `Arc<RwLock>` 