### PR TITLE
Warn if you run a debug build of kuksa-perf

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,9 @@ async fn main() -> Result<()> {
         buffer_size: args.buffer_size,
     };
 
+    if cfg!(debug_assertions) {
+        println!("Warning: You are running a debug build of kuksa-perf. This may affect performance measurements. If you want to run performance measurements, it is recommended you use a release build (cargo build --release).");
+    }
     perform_measurement(measurement_config, config_groups, shutdown_handler).await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,7 @@ async fn main() -> Result<()> {
         } else if let Some(skip_seconds) = args.skip_seconds {
             if duration <= skip_seconds {
                 eprintln!(
-                    "Error: `duration` ({}) cannot be smaller or equal than `skip_seconds` ({}).",
-                    duration, skip_seconds
+                    "Error: `duration` ({duration}) cannot be smaller or equal than `skip_seconds` ({skip_seconds})."
                 );
                 std::process::exit(1);
             }

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -162,7 +162,7 @@ async fn create_unix_socket_channel(path: impl AsRef<Path>) -> Result<Channel> {
 }
 
 async fn create_tcp_channel(host: String, port: u64) -> Result<Channel> {
-    let databroker_address = format!("{}:{}", host, port);
+    let databroker_address = format!("{host}:{port}");
 
     let endpoint = tonic::transport::Channel::from_shared(databroker_address.clone())
         .with_context(|| "Failed to parse server url")?;
@@ -180,7 +180,7 @@ async fn create_tcp_channel(host: String, port: u64) -> Result<Channel> {
             .uri()
             .port()
             .map_or("unknown port".to_string(), |p| p.to_string());
-        format!("Failed to connect to server {}:{}", host, port)
+        format!("Failed to connect to server {host}:{port}")
     })?;
 
     Ok(channel)
@@ -252,7 +252,7 @@ pub async fn perform_measurement(
 
         let signals = match ve {
             Ok(vec) => vec,
-            Err(e) => panic!("Error: {}", e),
+            Err(e) => panic!("Error: {e}"),
         };
         // Initialize receiving_end and initialize initial signal values.
         let (initial_values_sender, mut initial_values_reciever) =

--- a/src/triggering_ends/kuksa_val_v1/triggering_end.rs
+++ b/src/triggering_ends/kuksa_val_v1/triggering_end.rs
@@ -171,7 +171,7 @@ impl TriggeringEndInterface for TriggeringEnd {
         let response = client
             .get(proto::GetRequest { entries })
             .await
-            .map_err(|err| Error::MetadataError(format!("failed to fetch metadata: {}", err)))?;
+            .map_err(|err| Error::MetadataError(format!("failed to fetch metadata: {err}")))?;
 
         for entry in response.into_inner().entries.iter() {
             if let Some(metadata) = &entry.metadata {
@@ -195,8 +195,7 @@ impl TriggeringEndInterface for TriggeringEnd {
                 .collect();
 
             Err(Error::MetadataError(format!(
-                "The following signals are missing in the databroker: {:?}",
-                missing_signals
+                "The following signals are missing in the databroker: {missing_signals:?}"
             )))
         } else {
             Ok(signals_response)

--- a/src/triggering_ends/kuksa_val_v2/triggering_end.rs
+++ b/src/triggering_ends/kuksa_val_v2/triggering_end.rs
@@ -252,7 +252,7 @@ impl TriggeringEndInterface for TriggeringEnd {
                 }
                 Err(status) => {
                     // Handle the Err case without returning a value
-                    eprintln!("gRPC call failed with status: {:?}", status);
+                    eprintln!("gRPC call failed with status: {status:?}");
                 }
             }
         }
@@ -268,8 +268,7 @@ impl TriggeringEndInterface for TriggeringEnd {
                 .collect();
 
             Err(Error::MetadataError(format!(
-                "The following signals are missing in the databroker: {:?}",
-                missing_signals
+                "The following signals are missing in the databroker: {missing_signals:?}"
             )))
         } else {
             Ok(signals_response)

--- a/src/triggering_ends/sdv_databroker_v1/triggering_end.rs
+++ b/src/triggering_ends/sdv_databroker_v1/triggering_end.rs
@@ -135,7 +135,7 @@ impl TriggeringEndInterface for TriggeringEnd {
                 names: signals.clone(),
             }))
             .await
-            .map_err(|err| Error::MetadataError(format!("failed to fetch metadata: {}", err)))?;
+            .map_err(|err| Error::MetadataError(format!("failed to fetch metadata: {err}")))?;
 
         let signals_response: Vec<Signal> = response
             .into_inner()
@@ -163,8 +163,7 @@ impl TriggeringEndInterface for TriggeringEnd {
                 .collect();
 
             Err(Error::MetadataError(format!(
-                "The following signals are missing in the databroker: {:?}",
-                missing_signals
+                "The following signals are missing in the databroker: {missing_signals:?}"
             )))
         } else {
             Ok(signals_response)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,9 +37,9 @@ pub fn read_config(config_file: Option<&String>) -> Result<Vec<Group>> {
             let file = OpenOptions::new()
                 .read(true)
                 .open(filename)
-                .with_context(|| format!("Failed to open configuration file '{}'", filename))?;
+                .with_context(|| format!("Failed to open configuration file '{filename}'"))?;
             let config: Config = from_reader(file)
-                .with_context(|| format!("Failed to parse configuration file '{}'", filename))?;
+                .with_context(|| format!("Failed to parse configuration file '{filename}'"))?;
 
             Ok(config.groups)
         }
@@ -165,23 +165,19 @@ pub fn write_global_output(
             global_end_time.as_secs() // Return the adjusted seconds
         }
     };
-    writeln!(stdout, "  Total elapsed seconds: {}", total_elapsed_seconds)?;
+    writeln!(stdout, "  Total elapsed seconds: {total_elapsed_seconds}")?;
 
     let skip_seconds = match measurement_config.skip_seconds {
         Some(seconds) => {
-            writeln!(stdout, "  Skipped test seconds: {}", seconds)?;
+            writeln!(stdout, "  Skipped test seconds: {seconds}")?;
             seconds
         }
         None => 0,
     };
 
-    writeln!(stdout, "  Total signals: {} signals", global_signals_len,)?;
-    writeln!(stdout, "  Sent: {} signal updates", global_signals_sent,)?;
-    writeln!(
-        stdout,
-        "  Skipped: {} signal updates",
-        global_signals_skipped
-    )?;
+    writeln!(stdout, "  Total signals: {global_signals_len} signals",)?;
+    writeln!(stdout, "  Sent: {global_signals_sent} signal updates",)?;
+    writeln!(stdout, "  Skipped: {global_signals_skipped} signal updates")?;
     writeln!(stdout, "  Received: {} signal updates", global_hist.len())?;
 
     let elapsed_seconds = match measurement_config.duration {
@@ -245,9 +241,9 @@ pub fn write_output(measurement_result: &MeasurementResult) -> Result<()> {
     )?;
     let rate_limit = match measurement_config.interval {
         0 => "None".into(),
-        ms => format!("{} ms between iterations", ms),
+        ms => format!("{ms} ms between iterations"),
     };
-    writeln!(stdout, "  Rate limit: {}", rate_limit)?;
+    writeln!(stdout, "  Rate limit: {rate_limit}")?;
     writeln!(
         stdout,
         "  Sent: {} iterations * {} signals = {} updates",
@@ -268,7 +264,7 @@ pub fn write_output(measurement_result: &MeasurementResult) -> Result<()> {
 
     let skip_seconds = match measurement_config.skip_seconds {
         Some(seconds) => {
-            writeln!(stdout, "  Skipped test seconds: {}", seconds)?;
+            writeln!(stdout, "  Skipped test seconds: {seconds}")?;
             seconds
         }
         None => 0,
@@ -279,7 +275,7 @@ pub fn write_output(measurement_result: &MeasurementResult) -> Result<()> {
         None => measurement_context.hist.len() / (total_duration.as_secs() - skip_seconds),
     };
 
-    writeln!(stdout, "  Throughput: {} signal/second", throughput)?;
+    writeln!(stdout, "  Throughput: {throughput} signal/second")?;
 
     writeln!(
         stdout,
@@ -325,7 +321,7 @@ pub fn output_latency_to_file(
     fs::create_dir_all(output_dir)?;
 
     // Create the file path within the output directory
-    let file_path = format!("{}/{}.csv", output_dir, group_name);
+    let file_path = format!("{output_dir}/{group_name}.csv");
     // Create the CSV file using the group name
     let file = File::create(&file_path)?;
     let mut writer = Writer::from_writer(file);


### PR DESCRIPTION
This is printing a warning when a debug build of kuksa-perf is being used.

I think it makes sense fro a performance test, as by default `cargo build` will give you a debug-enabled build.

This is just a warning, so measurements are of course still working as intended when using a debug build.

Solves #16 

Note: This is actually only a one-line change, but I needed to touch more places, because clippy became more opinionated about how to use format strings.